### PR TITLE
join on indexer

### DIFF
--- a/includes/TripalFields/data__ontology_data/data__ontology_data.inc
+++ b/includes/TripalFields/data__ontology_data/data__ontology_data.inc
@@ -200,6 +200,7 @@ class data__ontology_data extends TripalField {
         $query->condition('tct.organism_id', $record_id, '=');
       }
 
+      $query->join('public.tripal_cvterm_entity_linker', 'tcel', 'tcel.entity_id = tbt.entity_id');
       $results = ((int) $query->countQuery()->execute()->fetchField()) > 1;
     }
 


### PR DESCRIPTION
resolve #58 for real this time.  we just join on the linker table.  previously we only checked if entities existed, not if those entities had annotations loaded.

![screen shot 2018-08-02 at 3 05 20 pm](https://user-images.githubusercontent.com/7063154/43605157-8cbe216c-9665-11e8-96db-a1e3465d743d.png)
